### PR TITLE
Check if $meta is actually an array before using it's values.

### DIFF
--- a/src/Parser/ImageParser.php
+++ b/src/Parser/ImageParser.php
@@ -102,6 +102,11 @@ final class ImageParser implements ParserInterface
         $matchedSize = 'full';
 
         $meta = wp_get_attachment_metadata($id);
+
+        if (! is_array($meta)) {
+            return $matchedSize;
+        }
+
         $sizes = $meta['sizes'];
         $sizes['full'] = [
             'file' => basename($meta['file']),


### PR DESCRIPTION
Sometimes, wp_get_attachment_metadata() returns an empty string or false, which causes a fatal error when accessing $meta['file'] later on. This checks if $meta is an array, and if not, returns $matchadSize without further checks.